### PR TITLE
corrected path error for get-qdbg.py

### DIFF
--- a/get-qdbg.py
+++ b/get-qdbg.py
@@ -17,6 +17,7 @@ What this means is that one qdbg installation can serve for multiple
 Python versions.
 """
 import argparse
+import glob
 import hashlib
 import json
 import os
@@ -514,6 +515,9 @@ class Installer:
 
         try:
             self._make_lib(version)
+            shutil.move(glob.glob(f'{QDBG_LIB}/*/qdbg')[-1], QDBG_LIB)
+            shutil.rmtree(glob.glob(f'{QDBG_LIB}/qdbg-*')[-1])
+            
         except Exception:
             if not os.path.exists(QDBG_LIB_BACKUP):
                 raise


### PR DESCRIPTION
Fix for import error when qdbg is not installed in Python environment